### PR TITLE
Fix path in docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN apk add --no-cache git make && \
 
 FROM alpine:3.13
 COPY --from=build /s5cmd/s5cmd .
-ENTRYPOINT ["./s5cmd"]
+WORKDIR /aws
+ENTRYPOINT ["/s5cmd"]


### PR DESCRIPTION
Changes relative path to absolute path so a user can easily mount his working dir to the docker
Adds empty workdir similar to aws cli